### PR TITLE
Remove explicit deny(..) of None

### DIFF
--- a/app_server.py
+++ b/app_server.py
@@ -54,7 +54,6 @@ class AppServer(object):
 				print("ZAP requires CurveZMQ (crypto) to be enabled. Exiting.")
 				sys.exit(1)
 			self.auth = IOLoopAuthenticator(self.ctx)
-			self.auth.deny(None)
 			print("ZAP enabled.\nAuthorizing clients in %s." % self.keymonkey.authorized_clients_dir)
 			self.auth.configure_curve(domain='*', location=self.keymonkey.authorized_clients_dir)
 			self.auth.start()


### PR DESCRIPTION
The explicit deny(None) is throwing:
```
Traceback (most recent call last):
  File "app_server.py", line 98, in <module>
    main()
  File "app_server.py", line 95, in main
    my_server.start()
  File "app_server.py", line 57, in start
    self.auth.deny(None)
  File "/home/XXX/XXX/site-packages/zmq/auth/base.py", line 85, in deny
    self.log.debug("Denying %s", ','.join(addresses))
TypeError: sequence item 0: expected str instance, NoneType found
``` 
I assume it's an issue with a newer version of python or ZMQ (this was on 4.2.5) but I think this is safe to just remove.